### PR TITLE
Adding Haslam-based Sky Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ PyGDSM
 
 
 This package includes interfaces to:
- * **GSM2008:** A model of diffuse Galactic radio emission from 10 MHz to 100 GHz, [Oliveira-Costa et. al., (2008)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.388..247D/abstract).
+ * **GSM2008:** A model of diffuse Galactic radio emission from 10 MHz to 100 GHz, [Oliveira-Costa et. al., (2008)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.388..247D/abstract). 
  * **GSM2016:** An improved model of diffuse galactic radio emission from 10 MHz to 5 THz, [Zheng et. al., (2016)](https://ui.adsabs.harvard.edu/abs/2017MNRAS.464.3486Z/abstract).
  * **LFSS:** The LWA1 Low Frequency Sky Survey (10-408 MHz) [Dowell et. al. (2017)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.388..247D/abstracthttp://arxiv.org/abs/1605.04920). **Note: LFSS methods are in beta!!**
-
-This is *not* a wrapper of the original code, it is a python-based equivalent that provides a uniform API with some additional features and advantages, such as healpy integration for imaging, and sky rotation for observed skies. 
+ * **Haslam:** A frequency-scaled model using a spectral index, based on the [Haslam 408 MHz](https://lambda.gsfc.nasa.gov/product/foreground/fg_2014_haslam_408_info.cfm) all-sky map.
+In general, these are *not* wrappers of the original code (GSM2008 was written in Fortan and GSM2016 in C); instead they provides a uniform API with some additional features and advantages, such as healpy integration for imaging, and sky rotation for observed skies. 
 
 
 Quickstart
@@ -37,9 +37,9 @@ Then you should be able to install with:
 
 Alternatively, clone the directory:
 
-        git clone https://github.com/telegraphic/PyGDSM
+        git clone https://github.com/telegraphic/pygdsm
        
-An run `pip install .`. On first run, the sky model data will be downloaded from Zenodo. These are about 500 MB total, and will be downloaded into your astropy cache (`~/.astropy/`). The data are hosted on [Zenodo](https://zenodo.org/record/3479985#.XaASx79S-AY).
+An run `pip install .`. On first run, the sky model data will be downloaded from Zenodo / LAMBDA. These are about 500 MB total, and will be downloaded into your astropy cache (`~/.astropy/`). The data are hosted on [Zenodo](https://zenodo.org/record/3479985#.XaASx79S-AY).
 
 Examples
 ---------
@@ -54,50 +54,45 @@ Q & A
 **Q. What's the difference between this and the `gsm.f` from the main GSM2008 website?**
      The `gsm.f` is a very basic Fortran code, which reads and writes values to and from
      ASCII files, and uses a command line interface for input. If you want to run this code
-     on an ancient computer with nothing by Fortran installed, then `gsm.f` is the way to go. 
-     In contrast, `PyGSM` is a Python code that leverages a lot of other Packages so that you 
+     on an ancient computer with nothing but Fortran installed, then `gsm.f` is the way to go. 
+     In contrast, `PyGDSM` is a Python code that leverages a lot of other Packages so that you 
      can do more stuff more efficiently. For example: you can view a sky model in a healpy 
      image; you can write a sky model to a Healpix FITS file; and believe it or not, the 
      Python implementation is *much faster*. Have a look at the 
      [quickstart guide](http://nbviewer.ipython.org/github/telegraphic/PyGSM/blob/master/docs/pygsm_quickstart.ipynb)
-     to get a feel for what `PyGSM` does.
+     to get a feel for what `PyGDSM` does.
 
-**Q. Are the outputs of `gsm.f` and `pygsm` identical?** At the moment: **no**. The cubic
-     spline interpolation implementation differs, so values will differ by as much as 
-     a few percent. The interpolation code used in `gsm.f` does not have an open-source
+**Q. Are the outputs of `gsm.f` and `pygdsm` identical?**.  
+     **NO**. The cubic  spline interpolation implementation differs, so values will differ by as 
+     much as a few percent. The interpolation code used in `gsm.f` does not have an open-source
      license (it's from [Numerical Recipes](http://www.nr.com/licenses/) ), so we haven't 
      implemented it (one could probably come up with an equivalent that didn't infringe).
      Nevertheless, the underlying PCA data are identical, and I've run tests to check that
      the two outputs are indeed comparable. 
 
-**Q. What's the difference between this and the Zheng et. al. github repo?**
-     `pygsm` provides two classes: `GlobalSkyModel2016()` and `GSMObserver2016()`, which once instantiated
+**Q. What's the difference between this and the [Zheng et. al. github repo](https://github.com/jeffzhen/gsm2016)?**
+     `pygdsm` provides two classes: `GlobalSkyModel2016()` and `GSMObserver2016()`, which once instantiated
      provide methods for programatically generating sky models. The Zheng et. al. github repo is a 
      simple, low-dependency, command line tool. Have a look at the 
      [GSM2016 quickstart guide](http://nbviewer.ipython.org/github/telegraphic/PyGSM/blob/master/docs/pygsm2016_quickstart.ipynb)
      to get a feel for what `PyGSM` does.
 
-**Q. Why is this package so large?**
+**Q. Why does this package download so much data when first run?**
      The package size is dominated by the PCA healpix maps, which have about 3 million points each.
      They're compressed using HDF5 LZF, so are actually about 3x smaller than the `*.dat`
      files that come in the original `gsm.tar.gz` file. The next biggest thing is test data,
      so that the output can be compared against precomputed output from `gsm.f`. The package now also includes
      the Zheng et. al. data, which is another ~300 MB.
-
-**Q. Why do I need h5py?**
-     `h5py` is required to read the PCA data, which are stored in a HDF5 file. Reading from
-     HDF5 into Python is incredibly efficient, and the compression is transparent to the end user.
-     This means that you can't eyeball the data using `vim` or `less` or a text editor, but if
-     you're trying to do that on a file with millions of data points you're doing science wrong anyway.
    
 
 References
 ----------
 
-The PCA data contained here is from:
+The sky model data contained here is from:
 * GSM2008 http://space.mit.edu/~angelica/gsm/index.html 
 * GSM2016 https://github.com/jeffzhen/gsm2016
 * LFSS https://lda10g.alliance.unm.edu/LWA1LowFrequencySkySurvey/
+* Haslam https://lambda.gsfc.nasa.gov/product/foreground/fg_2014_haslam_408_info.cfm
 
 
 ```
@@ -114,6 +109,13 @@ https://ui.adsabs.harvard.edu/abs/2017MNRAS.464.3486Z/abstract
 The LWA1 Low Frequency Sky Survey
 J. Dowell, G. B. Taylor, F. Schinzel, N. E. Kassim, K. Stovall
 MNRAS, 469, 4, 4537-4550 (2017)
+https://ui.adsabs.harvard.edu/abs/2017MNRAS.469.4537D/abstract
+
+An improved source-subtracted and destriped 408-MHz all-sky map 
+M. Remazeilles, C. Dickinson,A.J. Banday,  M. Bigot-Sazy, T. Ghosh
+MNRAS 451, 4, 4311-4327 (2014)
+https://ui.adsabs.harvard.edu/abs/2015MNRAS.451.4311R/abstract
+ 
 ```
 
 PyGSDM has an [ascl.net entry](https://ascl.net/1603.013):

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ PyGDSM
 
 `PyGDSM` is a Python interface for global diffuse sky models: all-sky maps in Healpix format of diffuse Galactic radio emission.
 
-
 This package includes interfaces to:
  * **GSM2008:** A model of diffuse Galactic radio emission from 10 MHz to 100 GHz, [Oliveira-Costa et. al., (2008)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.388..247D/abstract). 
  * **GSM2016:** An improved model of diffuse galactic radio emission from 10 MHz to 5 THz, [Zheng et. al., (2016)](https://ui.adsabs.harvard.edu/abs/2017MNRAS.464.3486Z/abstract).
- * **LFSS:** The LWA1 Low Frequency Sky Survey (10-408 MHz) [Dowell et. al. (2017)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.388..247D/abstracthttp://arxiv.org/abs/1605.04920). **Note: LFSS methods are in beta!!**
+ * **LFSS:** The LWA1 Low Frequency Sky Survey (10-408 MHz) [Dowell et. al. (2017)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.388..247D/abstracthttp://arxiv.org/abs/1605.04920). 
  * **Haslam:** A frequency-scaled model using a spectral index, based on the [Haslam 408 MHz](https://lambda.gsfc.nasa.gov/product/foreground/fg_2014_haslam_408_info.cfm) all-sky map.
+
 In general, these are *not* wrappers of the original code (GSM2008 was written in Fortan and GSM2016 in C); instead they provides a uniform API with some additional features and advantages, such as healpy integration for imaging, and sky rotation for observed skies. 
 
 

--- a/pygdsm/__init__.py
+++ b/pygdsm/__init__.py
@@ -7,3 +7,6 @@ from .pygsm2016 import GSMObserver2016
 
 from .lfsm import LowFrequencySkyModel
 from .lfsm import LFSMObserver
+
+from .haslam import HaslamSkyModel
+from .haslam import HaslamObserver

--- a/pygdsm/base_observer.py
+++ b/pygdsm/base_observer.py
@@ -65,8 +65,8 @@ class BaseObserver(ephem.Observer):
         sky_rotated = sky[pix0]
 
         # Generate a mask for below horizon
-        mask1 = self._phi + np.pi / 2 > 2 * np.pi
-        mask2 = self._phi < np.pi / 2
+        mask1 = g1 + np.pi / 2 > 2 * np.pi
+        mask2 = g1 < np.pi / 2
         mask = np.invert(np.logical_or(mask1, mask2))
 
         self.observed_sky = hp.ma(sky_rotated)

--- a/pygdsm/component_data.py
+++ b/pygdsm/component_data.py
@@ -10,3 +10,6 @@ GSM2008_TEST_DATA = download_file('https://zenodo.org/record/3835582/files/gsm_f
 
 LFSM_FILEPATH = download_file('https://zenodo.org/record/3835582/files/lfsm.h5?download=1',
                               cache=True, show_progress=True)
+
+HASLAM_FILEPATH = download_file('https://lambda.gsfc.nasa.gov/data/foregrounds/haslam_2014/haslam408_dsds_Remazeilles2014.fits',
+                                cache=True, show_progress=True)

--- a/pygdsm/haslam.py
+++ b/pygdsm/haslam.py
@@ -11,13 +11,36 @@ from .base_observer import BaseObserver
 class HaslamSkyModel(BaseSkyModel):
     """ Haslam destriped, desourced sky model """
 
-    def __init__(self,  freq_unit='MHz', spectral_index=-2.55):
+    def __init__(self,  freq_unit='MHz', spectral_index=-2.6):
         """ Global sky model (GSM) class for generating sky models.
 
         Parameters
         ----------
         freq_unit (str): Frequency unit to use, defaults to MHz
         spectral_index (float): Spectral index to use for calculations.
+
+        Notes
+        -----
+        This is a crude model; the sky's spectral index changes with sidereal time
+        and a singular spectral index is not realistic. Here are some measured values
+        at different frequencies:
+
+            Frequency        Spectral Index        Reference     Notes
+            50--100 MHz     si = -2.56 +/- 0.03    Mozdzen+19    LST 0--12 hr
+                                  2.46 +/- 0.01                  LST 18.2 hr
+            90--190 MHz     si = -2.61 +/- 0.01    Mozdzen+16    LST 0--12 hr
+                                 −2.50 +/- 0.02                  LST 17.7 hr
+            0.4--4.7 GHz 	si = −2.85 +/- 0.05    Dickinson+19
+            0.4--22.8 GHz 	si = −2.88 +/- 0.03    Dickinson+19
+            4.7--22.8 GHz 	si = −2.91 +/- 0.04    Dickinson+19
+            22.8--44 GHz 	si = −2.85 +/- 0.14    Dickinson+19
+
+        References
+        ----------
+        Mozdzen et al (2016), EDGES high-band, https://doi.org/10.1093/mnras/stw2696
+        Mozdzen et al (2019), EDGES low-band, https://doi.org/10.1093/mnras/sty3410
+        Dickinson et al (2019), C-BASS experiment, https://doi.org/10.1093/mnras/stz522
+
         """
         data_unit = 'K'
         basemap = 'Haslam'

--- a/pygdsm/haslam.py
+++ b/pygdsm/haslam.py
@@ -1,0 +1,63 @@
+import numpy as np
+from astropy import units
+import healpy as hp
+from scipy.interpolate import interp1d
+
+from .component_data import HASLAM_FILEPATH
+from .base_skymodel import BaseSkyModel
+from .base_observer import BaseObserver
+
+
+class HaslamSkyModel(BaseSkyModel):
+    """ Haslam destriped, desourced sky model """
+
+    def __init__(self,  freq_unit='MHz', spectral_index=-2.55):
+        """ Global sky model (GSM) class for generating sky models.
+
+        Parameters
+        ----------
+        freq_unit (str): Frequency unit to use, defaults to MHz
+        spectral_index (float): Spectral index to use for calculations.
+        """
+        data_unit = 'K'
+        basemap = 'Haslam'
+        super(HaslamSkyModel, self).__init__('Haslam', HASLAM_FILEPATH, freq_unit, data_unit, basemap)
+        self.spectral_index = spectral_index
+        self.data = hp.read_map(self.fits, verbose=False, dtype=np.float64)
+
+    def generate(self, freqs):
+        """ Generate a global sky model at a given frequency or frequencies
+
+        Parameters
+        ----------
+        freqs: float or np.array
+            Frequency for which to return GSM model
+
+        Returns
+        -------
+        gsm: np.array
+            Global sky model in healpix format, with NSIDE=256. Output map
+            is in galactic coordinates, and in antenna temperature units (K).
+
+        """
+        # convert frequency values into Hz
+        freqs = np.array(freqs) * units.Unit(self.freq_unit)
+        freqs_mhz = freqs.to('MHz').value
+
+        if isinstance(freqs_mhz, float):
+            freqs_mhz = np.array([freqs_mhz])
+
+        map_out = self.data * (freqs_mhz / 408.0) ** (self.spectral_index)
+
+        self.generated_map_data = map_out
+        self.generated_map_freqs = freqs
+        return map_out
+
+
+class HaslamObserver(BaseObserver):
+    def __init__(self):
+        """ Initialize the Observer object.
+
+        Calls ephem.Observer.__init__ function and adds on gsm
+        """
+        super(HaslamObserver, self).__init__(gsm=HaslamSkyModel)

--- a/pygdsm/lfsm.py
+++ b/pygdsm/lfsm.py
@@ -86,6 +86,7 @@ class LowFrequencySkyModel(BaseSkyModel):
         self.generated_map_freqs = freqs
         return map_out
 
+
 class LFSMObserver(BaseObserver):
     def __init__(self):
         """ Initialize the Observer object.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.1.0',
 
     description='Python Global Sky Model of diffuse Galactic radio emission',
     long_description=long_description,


### PR DESCRIPTION
Frequency scaling the Haslam 408 MHz map with a spectral index is common in pulsar community (at least around ~100 MHz to a few GHz), so adding in this functionality with a `HaslamSkyModel` and `HaslamObserver` class. 