### PR TITLE
Fix PyPi Distribution Files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements*.txt

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.1',
+    version='1.5.2',
 
     description='Python Global Sky Model of diffuse Galactic radio emission',
     long_description=long_description,


### PR DESCRIPTION
Hey Danny,

While the README does mention the intent that you should install the module from the git repo, I blindly tried to install it from pypi today and found that the install was broken, causing a FileNotFound error during the build as the setup.py file needs the requirements*.txt files to be present, but they weren't being copied to the distribution tar:
```bash
❯ pip install pygdsm
Collecting pygdsm
  Using cached pygdsm-1.5.1.tar.gz (20 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/8d/w_118rx95_74qx_pgrx679pw0000gp/T/pip-install-rogx4dy6/pygdsm_d5cbdaef9e2e4fa2a51b60049c174cf6/setup.py", line 16, in <module>
          with open("requirements.txt", 'r') as fh:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<frozen codecs>", line 918, in open
      FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

This MR simply includes those files by adding a MANIFEST.in file (tried using data_files and package_data kwargs in the setup() call to no avail), and bumps the version so that the fix is ready to be uploaded after a tag.

I tested this on a fork that I pushed to the testpypi instance, you can verify that the fix has worked on a clean python install using that distribution if you wish (https://test.pypi.org/project/debug-dpypi-pygdsm/), though you may need to pre-install setuptools via pip (failed otherwise for me as there isn't an upload of setuptools on testpypi):
```pip install -i https://test.pypi.org/simple/ debug-dpypi-pygdsm```

Cheers,
David