### PR TITLE
Fix setup.cfg using `description-file` instead of `description_file`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 universal=1
 
 [metadata]
-description-file=README.md
+description_file=README.md
 
 [aliases]
 test=pytest


### PR DESCRIPTION
One other quick thing I noticed while working on MR #20 was that `setuptools` was producing a warning regarding the use of `description-file` in `setup.cfg`, this is visible in the deployment of 1.5.1 [here](https://github.com/telegraphic/pygdsm/actions/runs/8476056945/job/23225077352#step:5:11).

This MR simply follows their advise and swaps out the `description-file` key to `description_file` to remove the warning.