### PR TITLE
Silence deprecation warning by removing the hp.read_map verbose kwarg

### DIFF
--- a/pygdsm/haslam.py
+++ b/pygdsm/haslam.py
@@ -52,7 +52,7 @@ class HaslamSkyModel(BaseSkyModel):
 
         super(HaslamSkyModel, self).__init__('Haslam', HASLAM_FILEPATH, freq_unit, data_unit, basemap)
         self.spectral_index = spectral_index
-        self.data = hp.read_map(self.fits, verbose=False, dtype=np.float64) - T_CMB
+        self.data = hp.read_map(self.fits, dtype=np.float64) - T_CMB
         self.nside = 512
 
         self.include_cmb = include_cmb


### PR DESCRIPTION
Noticed this warning while running pytest for the other MR. 

This kwarg no longer does anything, as per the docs. https://healpy.readthedocs.io/en/latest/generated/healpy.fitsfunc.read_map.html#:~:text=verbosebool%2C%20deprecated,has%20no%20effect