### PR TITLE
Replace `match` with if/else logic to restore compatiibility with earlier Python versions

### DIFF
--- a/pygdsm/__init__.py
+++ b/pygdsm/__init__.py
@@ -35,17 +35,18 @@ def init_gsm(gsm_name: str='gsm08'):
         sky_model (various): Corresponding sky model
     """
     gsm_name = gsm_name.lower().strip()
-    match gsm_name:
-        case 'gsm': # Shorthand for GSM08
-            return GlobalSkyModel()
-        case 'gsm08':
-            return GlobalSkyModel()
-        case 'gsm16':
-            return GlobalSkyModel16()
-        case 'lfsm':
-            return LowFrequencySkyModel()
-        case 'haslam':
-            return HaslamSkyModel()
+    if gsm_name == 'gsm': # Shorthand for GSM08
+        return GlobalSkyModel()
+    elif gsm_name == 'gsm08':
+        return GlobalSkyModel()
+    elif gsm_name == 'gsm16':
+        return GlobalSkyModel16()
+    elif gsm_name == 'lfsm':
+        return LowFrequencySkyModel()
+    elif gsm_name == 'haslam':
+        return HaslamSkyModel()
+    else:
+        raise ValueError(f'Invalid model specification "{gsm_name}"')
 
 
 def init_observer(gsm_name: str='gsm08'):
@@ -68,14 +69,16 @@ def init_observer(gsm_name: str='gsm08'):
         observer (various): Corresponding sky model observer
     """
     gsm_name = gsm_name.lower().strip()
-    match gsm_name:
-        case 'gsm': # Shorthand for GSM08
-            return GSMObserver()
-        case 'gsm08':
-            return GSMObserver()
-        case 'gsm16':
-            return GSMObserver16()
-        case 'lfsm':
-            return LFSMObserver()
-        case 'haslam':
-            return HaslamObserver()
+
+    if gsm_name == 'gsm': # Shorthand for GSM08
+        return GSMObserver()
+    elif gsm_name == 'gsm08':
+        return GSMObserver()
+    elif gsm_name == 'gsm16':
+        return GSMObserver16()
+    elif gsm_name == 'lfsm':
+        return LFSMObserver()
+    elif gsm_name == 'haslam':
+        return HaslamObserver()
+    else:
+        raise ValueError(f'Invalid model specification "{gsm_name}"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,9 @@ universal=1
 [metadata]
 description_file=README.md
 
+[options]
+python_requires = >=3.6
+
 [aliases]
 test=pytest
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
     ],


### PR DESCRIPTION
The `__init__.py` currently uses the `match` statement, which was introduced only in Python 3.10. Unfortunately, this means `pygdsm` is incompatible with earlier Python versions, in particular on clusters etc. where upgrading may not be straightforward. As far as I could tell, the match statement was in fact the only source of incompatibility with older Python versions, so here my suggestion to replace it with if/else logic instead.

I have verified this works on a local Python 3.6 installation. I have also added the `python_requires` argument to the `setup.cfg` file, as I think this is how `pip` can tell which Python versions are supported. I suppose the version number also has to be bumped before this can be released, but I am not sure exactly how/if you would like to proceed from here : )