### PR TITLE
fix formatting of ValueError if horizon_elevation is less than 0

### DIFF
--- a/pygdsm/base_observer.py
+++ b/pygdsm/base_observer.py
@@ -90,7 +90,7 @@ class BaseObserver(ephem.Observer):
 
         # Checking this separately encase someone tries to be smart and sets both the attribute and kwarg
         if self._horizon_elevation < 0:
-                raise ValueError(f"Horizon elevation must be greater or equal to 0 degrees ({np.rad2deg(horizon_elevation)=}).")
+            raise ValueError(f"Horizon elevation must be greater or equal to 0 degrees (currently {np.rad2deg(horizon_elevation)}).")
 
         # Match pyephem convertion -- string is degrees, int/float is rad
         horizon_elevation = ephem.degrees(horizon_elevation or 0.0)
@@ -102,7 +102,7 @@ class BaseObserver(ephem.Observer):
 
         # Checking this separately encase someone tries to be smart and sets both the attribute and kwarg
         if self._horizon_elevation < 0:
-                raise ValueError(f"Horizon elevation must be greater or equal to 0 degrees ({np.rad2deg(horizon_elevation)=}).")
+            raise ValueError(f"Horizon elevation must be greater or equal to 0 degrees (currently {np.rad2deg(horizon_elevation)}).")
 
         # Rotation is quite slow, only recompute if time or frequency has changed, or it has never been run
         if time_has_changed or self.observed_sky is None or horizon_has_changed:


### PR DESCRIPTION
~~Tiny bugfix - the error emitted if `horizon_elevation < 0` (added in #25) was not formatted correctly. Weirdly, this seems not to cause any issues on Python >= 3.8 (other than presumably raising a different error instead of raising the ValueError), but it seems Python <= 3.7 complains already at compile time, which breaks the module.~~

Okay, I was not familiar with this - apparently this is [annotated string formatting](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging), which was added only with Python 3.8. So this is actually just another compatibility fix for outdated Python versions : )